### PR TITLE
Expose Port as Environment Variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.12-alpine
 # Set build arguments
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}
+ENV EBB_PORT=${EBB_PORT:-5000}
 
 # Create User
 ARG UID=1000
@@ -16,6 +17,8 @@ COPY . /ebookbuddy
 WORKDIR /ebookbuddy
 RUN chown -R $UID:$GID /ebookbuddy
 
+RUN apk --no-cache --no-interactive update && apk --no-cache --no-interactive upgrade
+
 # Install Firefox and Xvfb
 RUN apk --no-cache add \
     firefox \
@@ -25,8 +28,9 @@ RUN apk --no-cache add \
     dbus
 
 # Install requirements and run code
-RUN pip install --no-cache-dir -r requirements.txt
-ENV PYTHONPATH "${PYTHONPATH}:/ebookbuddy/src"
-EXPOSE 5000
+RUN pip install --root-user-action=ignore --no-cache-dir --upgrade pip && \
+    pip install --root-user-action=ignore --no-cache-dir -r requirements.txt
+ENV PYTHONPATH="${PYTHONPATH}:/ebookbuddy/src"
+EXPOSE ${EBB_PORT}
 USER general_user
-CMD ["gunicorn", "src.eBookBuddy:app", "-c", "gunicorn_config.py"]
+CMD exec gunicorn src.eBookBuddy:app -b 0.0.0.0:${EBB_PORT} -c gunicorn_config.py

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,4 +1,3 @@
-bind = "0.0.0.0:5000"
 workers = 1
 threads = 4
 timeout = 120

--- a/src/eBookBuddy.py
+++ b/src/eBookBuddy.py
@@ -572,4 +572,4 @@ def overview(book):
 
 
 if __name__ == "__main__":
-    socketio.run(app, host="0.0.0.0", port=5000)
+    socketio.run(app)


### PR DESCRIPTION
Allows users to set EBB_PORT to the desired Port. Defaults to 5000 if not set.

Fixes #3 

Example Docker Compose:
```
services:
  ebookbuddy:
    image: thewicklowwolf/ebookbuddy:latest
    container_name: ebookbuddy
    network_mode: service:vpn
    restart: unless-stopped
    ports:
      - 5010:5010
    environment:
      EBB_PORT: 5010
      readarr_address: http://vpn:8788
      readarr_api_key: 1234567890
      root_folder_path: /data/eBooks/Collection/
      auto_start: True
      search_for_missing_book: True
    volumes:
      - /path/to/config:/ebookbuddy/config
      - /etc/localtime:/etc/localtime:ro
```